### PR TITLE
Remove explicit wallet lock in MasternodeList::StartAll()

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -162,7 +162,7 @@ void MasternodeList::StartAll(std::string strCommand)
             strFailedHtml += "\nFailed to start " + mne.getAlias() + ". Error: " + strError;
         }
     }
-    pwalletMain->Lock();
+
 
     std::string returnObj;
     returnObj = strprintf("Successfully started %d masternodes, failed to start %d, total %d", nCountSuccessful, nCountFailed, nCountFailed + nCountSuccessful);


### PR DESCRIPTION
Ref. this error from Dash, where a wallet goes in lock mode after using masternode start-all
Here's the fix in Dash;
https://github.com/dashpay/dash/pull/2106/commits/3f1334681c7db554a117f45c95f0fd0eb7d4145b
And the original issue;
https://github.com/dashpay/dash/issues/2104